### PR TITLE
Detect when yubikey is plugged out and plugged in again; and re-run SSH authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Our public (german) [security concept](https://sandstorm.de/de/datenschutz-und-d
 After connecting the YubiKey to a USB port `ssh-add -L` does not show it.
 
 1. reload the helper with `ykpiv-ssh-agent-helper --reload`
-1. vaidate that the process is running with `ps aux | grep -i ykpiv-ssh-agent-helper`
+1. validate that the process is running with `ps aux | grep -i ykpiv-ssh-agent-helper`
 1. check the YubiKey PIN store in the OS X keychain at _ykpiv-ssh-agent-helper_
-    * if not reset the PIN `ykpiv-ssh-agent-helper --reset-pin`
-    * an test again
-1. else try also resetting the PIN to ensure that
+    * if not then reset the PIN `ykpiv-ssh-agent-helper --reset-pin`
+    * … and test again
+1. otherwise try also resetting the PIN to ensure that
     * the stored PIN is correct
     * the YubiKey is not already locked due to too many PIN retries
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ykpiv-ssh-agent-helper FORKED with support for detecting attach of yubikeys
 
-I patched the helper with two functionalities:
+I patched the helper with the following functionalities:
 
 - when the yubikey is removed and attached again, re-run the initialization; ensuring SSH etc then works properly :)
 - make compatible with OSX 10.13 (move dylibs into /usr/local/lib)
-
+- install OpenSC alongside and use it internally (as it is the more robust PKCS11 library)
 
 (original Readme follows below)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# ykpiv-ssh-agent-helper FORKED with support for detecting attach of yubikeys
+
+I patched the helper with two functionalities:
+
+- when the yubikey is removed and attached again, re-run the initialization; ensuring SSH etc then works properly :)
+- make compatible with OSX 10.13 (move dylibs into /usr/local/lib)
+
+
+(original Readme follows below)
+
+--- 
+
 # ykpiv-ssh-agent-helper
 
 This is a dumb little utility to streamline the use of ssh-agent with

--- a/README.md
+++ b/README.md
@@ -5,12 +5,53 @@ I patched the helper with two functionalities:
 - when the yubikey is removed and attached again, re-run the initialization; ensuring SSH etc then works properly :)
 - make compatible with OSX 10.13 (move dylibs into /usr/local/lib)
 
-
 (original Readme follows below)
+
+Our public (german) [security concept](https://sandstorm.de/de/datenschutz-und-datensicherheit/sicherheitskonzept.html) contains a detailed step-by-step instruction how to use the 
+
+# Trouble–Shooting
+
+## missing key after YubiKey connect
+
+After connecting the YubiKey to a USB port `ssh-add -L` does not show it.
+
+1. reload the helper with `ykpiv-ssh-agent-helper --reload`
+1. vaidate that the process is running with `ps aux | grep -i ykpiv-ssh-agent-helper`
+1. check the YubiKey PIN store in the OS X keychain at _ykpiv-ssh-agent-helper_
+    * if not reset the PIN `ykpiv-ssh-agent-helper --reset-pin`
+    * an test again
+1. else try also resetting the PIN to ensure that
+    * the stored PIN is correct
+    * the YubiKey is not already locked due to too many PIN retries
+
+## agent refused operation
+
+This can have many reasons. Here is the most common.
+
+### libs not on ssh-agent whitelist
+
+Verify that the following files are regular files and no symlinks:
+
+- _/usr/local/lib/libykpiv.1.dylib_
+- _/usr/local/lib/libykcs11.dylib_
+- _/usr/local/lib/libcrypto.1.0.0.dylib_
+
+In case of links, remove the links and copy the file from _/opt/yubico-piv-tool/lib/_.
+
+## enable ssh-agent logs
+
+```sh
+# start ssh-agent in debugging mode
+killall -KILL ssh-agent
+ssh-agent -d
+# export SSH_AUTH_SOCK in another terminal
+# retry e.g. ssh-add
+# read log from first console
+```
 
 ---
 
-# ykpiv-ssh-agent-helper
+# (original README) ykpiv-ssh-agent-helper
 
 This is a dumb little utility to streamline the use of ssh-agent with
 PIV-enabled YubiKeys on OS X. While is specifically intended for use

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ I patched the helper with two functionalities:
 
 (original Readme follows below)
 
---- 
+---
 
 # ykpiv-ssh-agent-helper
 
@@ -28,9 +28,14 @@ In particularly, this tool is designed to solve two problems:
 
 # Build / Install
 
-Grab the latest yubico-piv-tool-x.x.x-mac.zip distribution from
+1. Grab the latest yubico-piv-tool-x.x.x-mac.zip distribution from
 https://developers.yubico.com/yubico-piv-tool/Releases/, and place it
-in the same directory containing this README.md. Then, run:
+in the same directory containing this README.md.
+
+2. Download OpenSC-0.18.0.dmg from https://github.com/OpenSC/OpenSC/releases, and
+place the "OpenSC 0.18.0.pkg" file in the same directory containing this README.md
+
+3. Then, run:
 
     ./pkg_build.sh
 

--- a/main.m
+++ b/main.m
@@ -373,7 +373,7 @@ void doWakeLoop(NSString *yubicoPivToolDir) {
     // and then (attempt to?) scrub it from memory when we're done with it.
 
 
-    NSString *pkcs11Module = @"/usr/local/lib/libykcs11.dylib";
+    NSString *pkcs11Module = @"/usr/local/lib/opensc-pkcs11.so";
     YKPIVSSHAgentHelper *helper = [[YKPIVSSHAgentHelper alloc] initWithPKCS11Path:pkcs11Module];
 
     // We assume this process will be started by launchd upon interactive login

--- a/main.m
+++ b/main.m
@@ -378,8 +378,8 @@ void doWakeLoop(NSString *yubicoPivToolDir) {
     // XXX ideally, we should read this from the keychain every time we wake up
     // and then (attempt to?) scrub it from memory when we're done with it.
     
-    NSString *pkcs11Module = [yubicoPivToolDir stringByAppendingPathComponent:@"lib/libykcs11.dylib"];
     
+    NSString *pkcs11Module = @"/usr/local/lib/libykcs11.dylib";
     YKPIVSSHAgentHelper *helper = [[YKPIVSSHAgentHelper alloc] initWithPKCS11Path:pkcs11Module];
     
     // We assume this process will be started by launchd upon interactive login

--- a/pkg_build.sh
+++ b/pkg_build.sh
@@ -42,6 +42,9 @@ if [[ -e "$XCODE_PROJECT" ]]; then
     [ $? -eq 0 ] || { printf "\nxcodebuild failed! Exiting now."; exit 1; }
     mv "$RUN_DIRECTORY/build/$TARGET_NAME" "${TMP_PATH}/$INSTALL_PREFIX/"
 
+    mkdir "${TMP_PATH}/tmp/"
+    cp OpenSC\ 0.18.0.pkg "${TMP_PATH}/tmp/"
+
     # unzip yubico-piv-tool-(version)-mac.zip
     mkdir -p "${TMP_PATH}/opt/$PIVTOOL_DIRNAME"
     unzip "$PIVTOOL_ZIPPATH" -d "${TMP_PATH}/opt/$PIVTOOL_DIRNAME"

--- a/pkg_build/ykpiv-ssh-agent-helper_scripts/postinstall
+++ b/pkg_build/ykpiv-ssh-agent-helper_scripts/postinstall
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# we try to remove the symlinks if they might exist - if we do NOT do this, it seems to happen (on modern macs ;) )
+# that the file is placed on the TARGET of the symlink; and not the symlink itself is overridden by the file (which is
+# what we need to ensure the whitelist works properly)
+rm -f /usr/local/lib/libykpiv.1.dylib /usr/local/lib/libykcs11.dylib /usr/local/lib/libcrypto.1.0.0.dylib
+
+
 # SECURITY FEATURE: the libs need to be in /usr/local/lib, as explained in https://github.com/OpenSC/OpenSC/issues/1008
 cp /opt/yubico-piv-tool/lib/libykpiv.1.dylib /usr/local/lib/
 cp /opt/yubico-piv-tool/lib/libykcs11.dylib /usr/local/lib/

--- a/pkg_build/ykpiv-ssh-agent-helper_scripts/postinstall
+++ b/pkg_build/ykpiv-ssh-agent-helper_scripts/postinstall
@@ -5,4 +5,6 @@ cp /opt/yubico-piv-tool/lib/libykpiv.1.dylib /usr/local/lib/
 cp /opt/yubico-piv-tool/lib/libykcs11.dylib /usr/local/lib/
 cp /opt/yubico-piv-tool/lib/libcrypto.1.0.0.dylib /usr/local/lib/
 
+# install OpenSC
+installer -pkg /tmp/OpenSC\ 0.18.0.pkg -target /
 exit 0

--- a/pkg_build/ykpiv-ssh-agent-helper_scripts/postinstall
+++ b/pkg_build/ykpiv-ssh-agent-helper_scripts/postinstall
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-echo "Hi"
+# SECURITY FEATURE: the libs need to be in /usr/local/lib, as explained in https://github.com/OpenSC/OpenSC/issues/1008
+cp /opt/yubico-piv-tool/lib/libykpiv.1.dylib /usr/local/lib/
+cp /opt/yubico-piv-tool/lib/libykcs11.dylib /usr/local/lib/
+cp /opt/yubico-piv-tool/lib/libcrypto.1.0.0.dylib /usr/local/lib/
 
 exit 0

--- a/ykpiv-ssh-agent-helper.xcodeproj/project.pbxproj
+++ b/ykpiv-ssh-agent-helper.xcodeproj/project.pbxproj
@@ -7,12 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9E73EC2D2021D3F90036E207 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E73EC2C2021D3F90036E207 /* IOKit.framework */; };
 		B8012F331C7E1AB9007EAE88 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8012F321C7E1AB9007EAE88 /* AppKit.framework */; };
 		B8012F351C7EADE9007EAE88 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B8012F341C7EADE9007EAE88 /* Security.framework */; };
 		B85C443F1D95B60600015B29 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B85C443E1D95B60600015B29 /* main.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9E73EC2C2021D3F90036E207 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		B8012F281C7E1A2B007EAE88 /* ykpiv-ssh-agent-helper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "ykpiv-ssh-agent-helper"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8012F321C7E1AB9007EAE88 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		B8012F341C7EADE9007EAE88 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -25,6 +27,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E73EC2D2021D3F90036E207 /* IOKit.framework in Frameworks */,
 				B8012F351C7EADE9007EAE88 /* Security.framework in Frameworks */,
 				B8012F331C7E1AB9007EAE88 /* AppKit.framework in Frameworks */,
 			);
@@ -33,6 +36,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9E73EC2B2021D3F90036E207 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				9E73EC2C2021D3F90036E207 /* IOKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		B8012F1F1C7E1A2B007EAE88 = {
 			isa = PBXGroup;
 			children = (
@@ -41,6 +52,7 @@
 				B8012F341C7EADE9007EAE88 /* Security.framework */,
 				B8012F321C7E1AB9007EAE88 /* AppKit.framework */,
 				B8012F291C7E1A2B007EAE88 /* Products */,
+				9E73EC2B2021D3F90036E207 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};

--- a/ykpiv-ssh-agent-helper.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ykpiv-ssh-agent-helper.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ykpiv-ssh-agent-helper.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ykpiv-ssh-agent-helper.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Problem Description

- run ykpiv-ssh-agent-helper
- run a ssh command (will work)
- unplug your yubikey
- re-plug your yubikey
- run a ssh command (will fail)

## Solution

Listen to USB attach events of yubikey and re-trigger SSH agent


## Additionally, fix for modern OSX SSH-Agent which only runs PKCS11 Dylibs in /usr/local/bin and /usr/bin

For me, this all makes a nice experience on OSX 10.13.2